### PR TITLE
Fix for encoding errors with Python3 during download of some index files

### DIFF
--- a/edgar/main.py
+++ b/edgar/main.py
@@ -94,7 +94,7 @@ def _download(file, dest):
                     _skip_header(z)
                     lines = z.read()
                     if IS_PY3:
-                        lines = str(lines, "utf-8")
+                        lines = str(lines, "latin-1")
                     lines = map(lambda line: _append_html_version(line),
                                 lines.splitlines())
                     idxfile.write('\n'.join(lines))


### PR DESCRIPTION
As discussed in the issues. A naive fix for encoding errors seems to be using latin-1 encoding instead of utf-8.