### PR TITLE
Skip files that are already present. This prevent re-downloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install python-edgar
 Call the library
 ```python
 import edgar
-edgar.download_index(download_directory, since_year)
+edgar.download_index(download_directory, since_year, skip_all_present_except_last=False)
 ```
 Output
 ```shell

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -1,1 +1,2 @@
 from .main import download_index
+from .main import _download as download

--- a/edgar/main.py
+++ b/edgar/main.py
@@ -111,7 +111,7 @@ def _download(file, dest, skip_file):
         raise logging.error("python-edgar only supports zipped index files")
 
 
-def download_index(dest, since_year, *, skip_all_present_except_last=False):
+def download_index(dest, since_year, skip_all_present_except_last=False):
     """
     Convenient method to download all files at once
     """

--- a/edgar/main.py
+++ b/edgar/main.py
@@ -76,17 +76,23 @@ def _url_get(url):
     return content
 
 
-def _download(file, dest):
+def _download(file, dest, skip_file):
     """
     Download an idx archive from EDGAR
     This will read idx files and unzip
     archives + read the master.idx file inside
+
+    when skip_file is True, it will skip the file if it's already present.
     """
     if not dest.endswith("/"):
         dest = "%s/" % dest
 
     url = file[0]
     dest_name = file[1]
+    if skip_file and os.path.exists(dest+dest_name):
+        logging.info("> Skipping %s" % (dest_name))
+        return
+
     if url.endswith("zip"):
         with tempfile.TemporaryFile(mode='w+b') as tmp:
             tmp.write(_url_get(url))
@@ -105,7 +111,7 @@ def _download(file, dest):
         raise logging.error("python-edgar only supports zipped index files")
 
 
-def download_index(dest, since_year):
+def download_index(dest, since_year, *, skip_all_present_except_last=False):
     """
     Convenient method to download all files at once
     """
@@ -119,8 +125,12 @@ def download_index(dest, since_year):
     logging.debug("worker count: %d", worker_count)
     pool = multiprocessing.Pool(worker_count)
 
-    for file in tasks:
-        pool.apply_async(_download, (file, dest))
+    for i, file in enumerate(tasks):
+        skip_file = skip_all_present_except_last
+        if i == 0:
+            # First one should always be re-downloaded
+            skip_file = False
+        pool.apply_async(_download, (file, dest, skip_file))
 
     pool.close()
     pool.join()

--- a/test.py
+++ b/test.py
@@ -3,6 +3,12 @@ import edgar
 import tempfile
 
 
+def _get_qtr_of_year(year=2019, qtr=1):
+    assert(1 <= qtr <= 4)
+    # Direct use of internal function
+    return edgar.main._quarterly_idx_list(year)[-4:4][-1 * qtr]
+
+
 class TestStringMethods(unittest.TestCase):
     def test_edgar(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -16,6 +22,20 @@ class TestStringMethods(unittest.TestCase):
                     first_line,
                     "1000045|NICHOLAS FINANCIAL INC|10-Q|2019-02-14|edgar/data/1000045/0001193125-19-039489.txt|edgar/data/1000045/0001193125-19-039489-index.html\n",
                 )
+
+    def test_skip_files(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            print("created temporary directory", tmpdirname)
+            data_qtr1_2019 = _get_qtr_of_year(year=2019, qtr=1)
+            file_name = tmpdirname + '/' + data_qtr1_2019[1]
+            # Now create a dummy file
+            with open(file_name, "wb") as fp:
+                fp.write(b"FAKE")
+            # download it with skipping
+            edgar.download(data_qtr1_2019, tmpdirname, skip_file=True)
+            # -> Should have ignored it!
+            with open(file_name, "r") as fp:
+                self.assertEqual(fp.readline(), "FAKE")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should skip already downloaded files. Saves on bandwidth (and time).
Only the last one (in time) will be re-downloaded (it's my expectation that the last one would change the most).
