### PR TITLE
Handle 403 from SEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Once `python-edgar` is finished downloading index files, you can open an index f
 `python-edgar` can be used as a library called from another python script, or as a standalone script.
 
 ## Features 
-- Fast: parallel downloads with `multiprocessing`. The more CPUs you have the faster it'll go.
+- Compliant: Follows fair acces guidelines established by the SEC at https://www.sec.gov/os/accessing-edgar-data
 - Efficient: retrieve compressed archives instead of raw index file that are 10 times bigger
 - Import as a library in your python project or run as a standalone script 
 - Python 3 only with 0 external dependencies (Python 3 only as of v3.0.0)

--- a/run.py
+++ b/run.py
@@ -43,9 +43,21 @@ if __name__ == "__main__":
         default=tempfile.mkdtemp(),
     )
 
+    parser.add_argument(
+        '-ua',
+        "-user-agent",
+        dest="ua",
+        help="The User Agent to set. This must be set properly "
+        + "else the SEC may temporarily ban you. See https://www.sec.gov/os/accessing-edgar-data"
+    )
+    
     args = parser.parse_args()
 
+    if args.ua is None:
+        logger.error("A user agent is required. See https://www.sec.gov/os/accessing-edgar-data")
+        sys.exit(1)
+        
     logger.debug("downloads will be saved to %s" % args.directory)
 
-    edgar.download_index(args.directory, args.year)
+    edgar.download_index(args.directory, args.year, args.ua)
     logger.info("Files downloaded in %s" % args.directory)


### PR DESCRIPTION
[ ] Require user agent with `-ua / --user-agent` such as `python run.py -y 2018 -ua "MyCo author@myco.com"`
[ ] Remove parallel processing since we cannot go fast anyway. Add basic time slicing to ensure we don't go over 5QPS