### PR TITLE
Added CLI argument to allow skipping files. Fixed UA argument name.

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import os
 import datetime
 import tempfile
 import sys
@@ -44,11 +43,22 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        '-ua',
-        "-user-agent",
+        "-ua",
+        "--user-agent",
         dest="ua",
         help="The User Agent to set. This must be set properly "
         + "else the SEC may temporarily ban you. See https://www.sec.gov/os/accessing-edgar-data"
+    )
+
+    parser.add_argument(
+        "-s",
+        "--skip-all-present-except-last",
+        action="store_true",
+        dest="skip",
+        help="Specify this flag to skip downloading filing index"
+        + " files that are already present. Only the most recent"
+        + " file is downloaded. If not specified all files are"
+        + " downloaded again."
     )
     
     args = parser.parse_args()
@@ -59,5 +69,5 @@ if __name__ == "__main__":
         
     logger.debug("downloads will be saved to %s" % args.directory)
 
-    edgar.download_index(args.directory, args.year, args.ua)
+    edgar.download_index(args.directory, args.year, args.ua, args.skip)
     logger.info("Files downloaded in %s" % args.directory)


### PR DESCRIPTION
@edouardswiac Greetings and thank you for the library.

I recently had a chance to use the standalone script and saw an opportunity to contribute. Specifically I've done the following:
- Added a CLI argument to allow skipping files that are already present. While the library has support for this, it could not be invoked from the standalone script.
- Added a hyphen to the user agent argument to keep it consistent with all the other arguments.
- Removed an unused `os` import.

With the addition of this CLI argument, the help now looks like:

```
usage: run.py [-h] [-y YEAR] [-d DIRECTORY] [-ua UA] [-s]

optional arguments:
  -h, --help            show this help message and exit
  -y YEAR, --from-year YEAR
                        The year from which to start downloading the filing
                        index. Default to current year
  -d DIRECTORY, --directory DIRECTORY
                        A directory where the filing index files willbe
                        downloaded to. Default to a temporary directory
  -ua UA, --user-agent UA
                        The User Agent to set. This must be set properly else
                        the SEC may temporarily ban you. See
                        https://www.sec.gov/os/accessing-edgar-data
  -s, --skip-all-present-except-last
                        Specify this flag to skip downloading filing index
                        files that are already present. Only the most recent
                        file is downloaded. If not specified all files are
                        downloaded again.
```

And the flag can be specified like so:

```
$ python run.py -y 2017 -ua "MyCompany edward@mycompany.com" -s
```
