### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install python-edgar
 Call the library
 ```python
 import edgar
-edgar.download_index(download_directory, since_year, user_agent, skip_all_present_except_last=False)
+edgar.download_index(dest, since_year, user_agent, skip_all_present_except_last=False)
 ```
 Output
 ```shell


### PR DESCRIPTION
Documentation updated.

While calling the python-edgar module, we'll get a destination error.

Before:
edgar.download_index(download_directory, since_year, user_agent, skip_all_present_except_last=False)

After:
edgar.download_index(dest, since_year, user_agent, skip_all_present_except_last=False)

It should be like this.