### PR TITLE
Run as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Output
 - Open your terminal inside that directory and run `python run.py -h`. You can specify a destination directory for downloaded index files like `-d edgar-idx` (defaults to a temporary directory) and/or specify the year from which you want to build the index with `-y 2017` (defaults to current year).
 
 ```shell
- $ python run.py -y 2017 -ua "MyCompany edward@mycompany.com"
+ $ python -m edgar -y 2017 -ua "MyCompany edward@mycompany.com"
 2018-06-23 12:41:46,451 - DEBUG - downloads will be saved to /var/folders/bv/2zbdkyyj14766dcw07x6zrrr0000gn/T/tmpr2Nk3o
 2018-06-23 12:41:46,451 - DEBUG - downloading files since 2017
 2018-06-23 12:41:46,451 - INFO - 6 index files to retrieve

--- a/edgar/__main__.py
+++ b/edgar/__main__.py
@@ -5,7 +5,7 @@ import sys
 from argparse import ArgumentParser
 import logging
 
-import edgar
+from edgar.main import download_index
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -69,5 +69,5 @@ if __name__ == "__main__":
         
     logger.debug("downloads will be saved to %s" % args.directory)
 
-    edgar.download_index(args.directory, args.year, args.ua, args.skip)
+    download_index(args.directory, args.year, args.ua, args.skip)
     logger.info("Files downloaded in %s" % args.directory)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     author_email="edouard.swiac@gmail.com",
     url="https://github.com/edouardswiac/python-edgar",
     packages=["edgar"],
-    scripts=["run.py"],
     license="MIT",
     keywords="edgar sec filings 10k 10q 13d 8k",
     classifiers=[


### PR DESCRIPTION
Moves run.py to edgar/__main__.py so that you can invoke the script from the command-line using `python -m edgar ...`